### PR TITLE
chore: `C0-Config` header replaces `C0-Upstream`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ HEAD|GET /fetch/{kind}/{object}
 |--------|----------|-------------|
 | `Range` | ✅ | Byte range in format `bytes={first}-{last}` |
 | `C0-Bucket` | ❌ | Bucket(s) containing the object |
-| `C0-Upstream` | ❌ | Override S3 request config |
+| `C0-Config` | ❌ | Override S3 request config |
 
 `C0-Bucket` behavior:
 - Multiple headers indicate bucket preference order
@@ -34,9 +34,11 @@ HEAD|GET /fetch/{kind}/{object}
 - Client preference may be overridden based on internal latency/error stats
 - At most 2 buckets attempted per page miss
 
-`C0-Upstream` overrides:
-Space-separated key-value pairs to override S3 request configuration, per page miss.
-- `ot=<ms>` Operation timeout
+`C0-Config` overrides:
+Space-separated key-value pairs to override S3 request configuration per page miss.
+- `ct=<ms>` Connect timeout (in case an existing connection could not be reused)
+- `rt=<ms>` Read timeout (time-to-first-byte)
+- `ot=<ms>` Operation timeout (across retries)
 - `oat=<ms>` Operation attempt timeout
 - `ma=<num>` Maximum attempts
 - `ib=<ms>` Initial backoff duration
@@ -49,7 +51,7 @@ GET /fetch/prod-videos/movie-2024.mp4 HTTP/1.1
 Range: bytes=1048576-18874367
 C0-Bucket: us-west-videos
 C0-Bucket: us-east-videos-backup
-C0-Upstream: ot=1500 ma=3
+C0-Config: ct=1000 oat=1500 ma=5 ib=10 mb=100
 ```
 
 #### Response

--- a/src/object_store/config.rs
+++ b/src/object_store/config.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct S3RequestProfile {
+pub struct RequestConfig {
+    pub connect_timeout: Option<Duration>,
+    pub read_timeout: Option<Duration>,
     pub operation_timeout: Option<Duration>,
     pub operation_attempt_timeout: Option<Duration>,
     pub max_attempts: Option<u32>,
@@ -9,9 +11,11 @@ pub struct S3RequestProfile {
     pub max_backoff: Option<Duration>,
 }
 
-impl S3RequestProfile {
+impl RequestConfig {
     pub fn is_noop(&self) -> bool {
-        self.operation_timeout.is_none()
+        self.connect_timeout.is_none()
+            && self.read_timeout.is_none()
+            && self.operation_timeout.is_none()
             && self.operation_attempt_timeout.is_none()
             && self.max_attempts.is_none()
             && self.initial_backoff.is_none()
@@ -21,6 +25,12 @@ impl S3RequestProfile {
     pub fn timeout_config(&self) -> aws_sdk_s3::config::timeout::TimeoutConfig {
         let mut builder = aws_sdk_s3::config::timeout::TimeoutConfig::builder();
 
+        if let Some(connect_timeout) = self.connect_timeout {
+            builder = builder.connect_timeout(connect_timeout);
+        }
+        if let Some(read_timeout) = self.read_timeout {
+            builder = builder.read_timeout(read_timeout);
+        }
         if let Some(timeout) = self.operation_timeout {
             builder = builder.operation_timeout(timeout);
         }

--- a/src/object_store/mod.rs
+++ b/src/object_store/mod.rs
@@ -1,7 +1,7 @@
+mod config;
 mod downloader;
-mod profile;
 mod stats;
 
+pub use config::RequestConfig;
 pub use downloader::{DownloadError, DownloadOutput, Downloader, ObjectPiece};
-pub use profile::S3RequestProfile;
 pub use stats::BucketMetrics;

--- a/src/service/routes.rs
+++ b/src/service/routes.rs
@@ -17,14 +17,14 @@ use http_body_util::{BodyExt as _, StreamBody};
 use tracing::{debug, instrument, warn};
 
 use crate::{
-    object_store::{DownloadError, S3RequestProfile},
+    object_store::{DownloadError, RequestConfig},
     service::{CacheyService, Chunk, ServiceError, metrics},
     types::{BucketName, BucketNameSet, ObjectKey, ObjectKind},
 };
 
 const CONTENT_TYPE: &str = "application/octet-stream";
 static C0_BUCKET_HEADER: HeaderName = HeaderName::from_static("c0-bucket");
-static C0_UPSTREAM_HEADER: HeaderName = HeaderName::from_static("c0-upstream");
+static C0_CONFIG_HEADER: HeaderName = HeaderName::from_static("c0-config");
 
 #[derive(Debug)]
 pub struct RangeHeader(pub Range<u64>);
@@ -65,31 +65,28 @@ where
     }
 }
 
-impl<S> FromRequestParts<S> for S3RequestProfile
+impl<S> FromRequestParts<S> for RequestConfig
 where
     S: Send + Sync,
 {
     type Rejection = (StatusCode, &'static str);
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        let Some(header_value) = parts.headers.get(&C0_UPSTREAM_HEADER) else {
-            return Ok(S3RequestProfile::default());
+        let Some(header_value) = parts.headers.get(&C0_CONFIG_HEADER) else {
+            return Ok(RequestConfig::default());
         };
 
-        let header_str = header_value.to_str().map_err(|_| {
-            (
-                StatusCode::BAD_REQUEST,
-                "Invalid C0-Upstream header encoding",
-            )
-        })?;
+        let header_str = header_value
+            .to_str()
+            .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid C0-Config header encoding"))?;
 
-        let mut profile = S3RequestProfile::default();
+        let mut config = RequestConfig::default();
 
         for pair in header_str.split_whitespace() {
             let Some((key, value)) = pair.split_once('=') else {
                 return Err((
                     StatusCode::BAD_REQUEST,
-                    "Malformed C0-Upstream header: missing '=' in key-value pair",
+                    "Malformed C0-Config header: missing '=' in key-value pair",
                 ));
             };
 
@@ -97,29 +94,31 @@ where
                 v.parse::<u64>().map(Duration::from_millis).map_err(|_| {
                     (
                         StatusCode::BAD_REQUEST,
-                        "Invalid duration value in C0-Upstream header",
+                        "Invalid duration value in C0-Config header",
                     )
                 })
             };
 
             match key {
-                "ot" => profile.operation_timeout = Some(parse_duration(value)?),
-                "oat" => profile.operation_attempt_timeout = Some(parse_duration(value)?),
+                "ct" => config.connect_timeout = Some(parse_duration(value)?),
+                "rt" => config.read_timeout = Some(parse_duration(value)?),
+                "ot" => config.operation_timeout = Some(parse_duration(value)?),
+                "oat" => config.operation_attempt_timeout = Some(parse_duration(value)?),
                 "ma" => {
-                    profile.max_attempts = Some(value.parse().map_err(|_| {
+                    config.max_attempts = Some(value.parse().map_err(|_| {
                         (
                             StatusCode::BAD_REQUEST,
-                            "Invalid max_attempts value in C0-Upstream header",
+                            "Invalid max_attempts value in C0-Config hheader",
                         )
                     })?)
                 }
-                "ib" => profile.initial_backoff = Some(parse_duration(value)?),
-                "mb" => profile.max_backoff = Some(parse_duration(value)?),
-                _ => return Err((StatusCode::BAD_REQUEST, "Unknown key in C0-Upstream header")),
+                "ib" => config.initial_backoff = Some(parse_duration(value)?),
+                "mb" => config.max_backoff = Some(parse_duration(value)?),
+                _ => {} // Ignore unrecognized keys
             }
         }
 
-        Ok(profile)
+        Ok(config)
     }
 }
 
@@ -152,7 +151,7 @@ pub async fn fetch(
     method: axum::http::Method,
     RangeHeader(byterange): RangeHeader,
     BucketHeaders(buckets): BucketHeaders,
-    s3_profile: S3RequestProfile,
+    req_config: RequestConfig,
 ) -> Response {
     let buckets = if buckets.is_empty() {
         BucketNameSet::new(std::iter::once(kind.clone().into()))
@@ -179,7 +178,7 @@ pub async fn fetch(
                 buckets,
                 byterange.clone(),
                 concurrency,
-                s3_profile,
+                req_config,
             )
             .await
             .peekable(),
@@ -349,102 +348,137 @@ fn on_chunk_error(
 
 #[cfg(test)]
 mod tests {
-    use axum::http::Request;
-
     use super::*;
+    use axum::http::{HeaderValue, Method, Request};
+    use std::time::Duration;
 
-    fn create_parts_with_headers(headers: Vec<(&HeaderName, &str)>) -> Parts {
-        let mut req = Request::builder();
-        for (name, value) in headers {
-            req = req.header(name, value);
-        }
-        let (parts, _) = req.body(()).unwrap().into_parts();
-        parts
+    async fn parse_c0_config(
+        header_value: &str,
+    ) -> Result<RequestConfig, (StatusCode, &'static str)> {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/")
+            .header(&C0_CONFIG_HEADER, header_value)
+            .body(())
+            .unwrap();
+
+        let (mut parts, _) = req.into_parts();
+        RequestConfig::from_request_parts(&mut parts, &()).await
     }
 
     #[tokio::test]
-    async fn test_s3_request_profile_default() {
-        let mut parts = create_parts_with_headers(vec![]);
-        let profile = S3RequestProfile::from_request_parts(&mut parts, &())
-            .await
+    async fn test_c0_config_empty_returns_default() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/")
+            .body(())
             .unwrap();
 
-        assert!(profile.operation_timeout.is_none());
-        assert!(profile.operation_attempt_timeout.is_none());
-        assert!(profile.max_attempts.is_none());
-        assert!(profile.initial_backoff.is_none());
-        assert!(profile.max_backoff.is_none());
+        let (mut parts, _) = req.into_parts();
+        let config = RequestConfig::from_request_parts(&mut parts, &())
+            .await
+            .unwrap();
+        assert_eq!(config, RequestConfig::default());
     }
 
     #[tokio::test]
-    async fn test_s3_request_profile_parse() {
-        let mut parts = create_parts_with_headers(vec![(
-            &C0_UPSTREAM_HEADER,
-            "ot=5000 oat=1000 ma=3 ib=100 mb=5000",
-        )]);
+    async fn test_c0_config_single_timeout() {
+        let config = parse_c0_config("ct=1000").await.unwrap();
+        assert_eq!(config.connect_timeout, Some(Duration::from_millis(1000)));
+        assert_eq!(config.read_timeout, None);
+    }
 
-        let profile = S3RequestProfile::from_request_parts(&mut parts, &())
+    #[tokio::test]
+    async fn test_c0_config_all_timeouts() {
+        let config = parse_c0_config("ct=1000 rt=2000 ot=3000 oat=1500")
             .await
             .unwrap();
-
-        assert_eq!(profile.operation_timeout, Some(Duration::from_millis(5000)));
+        assert_eq!(config.connect_timeout, Some(Duration::from_millis(1000)));
+        assert_eq!(config.read_timeout, Some(Duration::from_millis(2000)));
+        assert_eq!(config.operation_timeout, Some(Duration::from_millis(3000)));
         assert_eq!(
-            profile.operation_attempt_timeout,
-            Some(Duration::from_millis(1000))
+            config.operation_attempt_timeout,
+            Some(Duration::from_millis(1500))
         );
-        assert_eq!(profile.max_attempts, Some(3));
-        assert_eq!(profile.initial_backoff, Some(Duration::from_millis(100)));
-        assert_eq!(profile.max_backoff, Some(Duration::from_millis(5000)));
     }
 
     #[tokio::test]
-    async fn test_s3_request_profile_partial() {
-        let mut parts = create_parts_with_headers(vec![(&C0_UPSTREAM_HEADER, "ot=2000 ma=5")]);
+    async fn test_c0_config_backoff_settings() {
+        let config = parse_c0_config("ib=100 mb=5000 ma=3").await.unwrap();
+        assert_eq!(config.initial_backoff, Some(Duration::from_millis(100)));
+        assert_eq!(config.max_backoff, Some(Duration::from_millis(5000)));
+        assert_eq!(config.max_attempts, Some(3));
+    }
 
-        let profile = S3RequestProfile::from_request_parts(&mut parts, &())
+    #[tokio::test]
+    async fn test_c0_config_mixed_settings() {
+        let config = parse_c0_config("ct=1000 ma=5 ib=10 oat=1500")
             .await
             .unwrap();
-
-        assert_eq!(profile.operation_timeout, Some(Duration::from_millis(2000)));
-        assert_eq!(profile.operation_attempt_timeout, None);
-        assert_eq!(profile.max_attempts, Some(5));
-        assert_eq!(profile.initial_backoff, None);
-        assert_eq!(profile.max_backoff, None);
+        assert_eq!(config.connect_timeout, Some(Duration::from_millis(1000)));
+        assert_eq!(config.max_attempts, Some(5));
+        assert_eq!(config.initial_backoff, Some(Duration::from_millis(10)));
+        assert_eq!(
+            config.operation_attempt_timeout,
+            Some(Duration::from_millis(1500))
+        );
     }
 
     #[tokio::test]
-    async fn test_s3_request_profile_malformed_missing_equals() {
-        let mut parts = create_parts_with_headers(vec![(&C0_UPSTREAM_HEADER, "ot5000 ma=3")]);
-
-        let result = S3RequestProfile::from_request_parts(&mut parts, &()).await;
-
-        assert!(result.is_err());
-        let (status, msg) = result.unwrap_err();
-        assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert!(msg.contains("missing '='"));
+    async fn test_c0_config_ignores_unknown_keys() {
+        let config = parse_c0_config("ct=1000 unknown=123 rt=2000")
+            .await
+            .unwrap();
+        assert_eq!(config.connect_timeout, Some(Duration::from_millis(1000)));
+        assert_eq!(config.read_timeout, Some(Duration::from_millis(2000)));
     }
 
     #[tokio::test]
-    async fn test_s3_request_profile_invalid_duration() {
-        let mut parts = create_parts_with_headers(vec![(&C0_UPSTREAM_HEADER, "ot=abc")]);
-
-        let result = S3RequestProfile::from_request_parts(&mut parts, &()).await;
-
+    async fn test_c0_config_missing_equals() {
+        let result = parse_c0_config("ct1000").await;
         assert!(result.is_err());
-        let (status, msg) = result.unwrap_err();
-        assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert!(msg.contains("Invalid duration"));
+        assert_eq!(
+            result.unwrap_err().1,
+            "Malformed C0-Config header: missing '=' in key-value pair"
+        );
     }
 
     #[tokio::test]
-    async fn test_s3_request_profile_unknown_key() {
-        let mut parts = create_parts_with_headers(vec![(&C0_UPSTREAM_HEADER, "unknown=100")]);
-
-        let result = S3RequestProfile::from_request_parts(&mut parts, &()).await;
-
+    async fn test_c0_config_invalid_duration() {
+        let result = parse_c0_config("ct=invalid").await;
         assert!(result.is_err());
-        let (status, msg) = result.unwrap_err();
-        assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert!(msg.contains("Unknown key"));
+        assert_eq!(
+            result.unwrap_err().1,
+            "Invalid duration value in C0-Config header"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_c0_config_invalid_max_attempts() {
+        let result = parse_c0_config("ma=invalid").await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().1,
+            "Invalid max_attempts value in C0-Config hheader"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_c0_config_invalid_header_encoding() {
+        let mut req = Request::builder()
+            .method(Method::GET)
+            .uri("/")
+            .body(())
+            .unwrap();
+
+        req.headers_mut().insert(
+            &C0_CONFIG_HEADER,
+            HeaderValue::from_bytes(&[0xFF, 0xFE]).unwrap(),
+        );
+
+        let (mut parts, _) = req.into_parts();
+        let result = RequestConfig::from_request_parts(&mut parts, &()).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().1, "Invalid C0-Config header encoding");
     }
 }

--- a/tests/downloader_integration_test.rs
+++ b/tests/downloader_integration_test.rs
@@ -4,7 +4,7 @@ use aws_config::BehaviorVersion;
 use aws_sdk_s3::config::Credentials;
 use bytes::{Bytes, BytesMut};
 use cachey::{
-    object_store::{DownloadError, Downloader, S3RequestProfile},
+    object_store::{DownloadError, Downloader, RequestConfig},
     service::{PAGE_SIZE, SlidingThroughput},
     types::{BucketName, BucketNameSet, ObjectKey},
 };
@@ -97,7 +97,7 @@ async fn test_download_full_object() {
             &buckets,
             key,
             &Range { start: 0, end: 100 },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await
         .unwrap();
@@ -133,7 +133,7 @@ async fn test_download_partial_range() {
                 start: 1000,
                 end: 2000,
             },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await
         .unwrap();
@@ -156,7 +156,7 @@ async fn test_download_no_such_key() {
             &buckets,
             key,
             &Range { start: 0, end: 100 },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await;
 
@@ -190,7 +190,7 @@ async fn test_download_range_not_satisfied() {
                 start: 0,
                 end: 1000,
             },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await
         .unwrap();
@@ -222,7 +222,7 @@ async fn test_download_page_sized_range_from_small_object() {
                 start: 0,
                 end: PAGE_SIZE,
             },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await
         .unwrap();
@@ -275,7 +275,7 @@ async fn test_download_with_fallback_bucket() {
                 start: 0,
                 end: test_data.len() as u64,
             },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await
         .unwrap();
@@ -314,7 +314,7 @@ async fn test_download_multiple_ranges_same_object() {
 
     for range in ranges {
         let out = downloader
-            .download(&buckets, key.clone(), &range, &S3RequestProfile::default())
+            .download(&buckets, key.clone(), &range, &RequestConfig::default())
             .await
             .unwrap();
 
@@ -351,7 +351,7 @@ async fn test_download_with_hedged_requests() {
                     start: 0,
                     end: test_data.len() as u64,
                 },
-                &S3RequestProfile::default(),
+                &RequestConfig::default(),
             )
             .await
             .unwrap();
@@ -375,7 +375,7 @@ async fn test_download_empty_range() {
             &buckets,
             key,
             &Range { start: 10, end: 10 },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await;
 }
@@ -404,7 +404,7 @@ async fn test_download_last_byte() {
                 start: 1023,
                 end: 1024,
             },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await
         .unwrap();
@@ -440,7 +440,7 @@ async fn test_small_object_full_range() {
                 start: 0,
                 end: test_data.len() as u64,
             },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await
         .unwrap();
@@ -473,7 +473,7 @@ async fn test_small_object_partial_range() {
             &buckets,
             key,
             &Range { start: 10, end: 20 },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await
         .unwrap();
@@ -505,7 +505,7 @@ async fn test_1kb_object() {
                 start: 0,
                 end: test_data.len() as u64,
             },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await
         .unwrap();
@@ -538,7 +538,7 @@ async fn test_100kb_object_partial_range() {
                 start: 50000,
                 end: 60000,
             },
-            &S3RequestProfile::default(),
+            &RequestConfig::default(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
also add support for `ct` (connect timeout) & `rt` (read timeout) improving the coverage on knobs AWS SDK provides