### PR TITLE
fix: make Prometheus metrics registry opt-in

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -114,6 +114,7 @@ async fn main() -> eyre::Result<()> {
                 info!("disk cache disabled");
                 None
             },
+            metrics_registry: Some(prometheus::default_registry().clone()),
         },
         hedge_quantile: args.hedge_quantile,
     };

--- a/tests/server_integration_test.rs
+++ b/tests/server_integration_test.rs
@@ -57,6 +57,7 @@ async fn setup_test_server() -> TestContext {
         cache: CacheConfig {
             memory_size: ByteSize::mib(256),
             disk_cache: None,
+            metrics_registry: Some(prometheus::Registry::new()),
         },
         hedge_quantile: 0.99,
     };


### PR DESCRIPTION
## Summary
- Add optional `metrics_registry` field to `CacheConfig`
- Only register foyer metrics when a registry is explicitly provided
- Server passes the default registry for production metrics
- Tests use isolated registries to prevent duplicate registration panics

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)