### PR TITLE
fix(ci): use buildx imagetools for multi-arch manifest creation

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -89,14 +89,12 @@ jobs:
 
       - name: Create and push versioned manifest
         run: |
-          docker manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release-plz.outputs.version }} \
+          docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release-plz.outputs.version }} \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release-plz.outputs.version }}-x86-64 \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release-plz.outputs.version }}-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release-plz.outputs.version }}
 
       - name: Create and push latest manifest
         run: |
-          docker manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+          docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-x86-64 \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
## Summary
- `docker manifest create` fails when source images are manifest lists, which happens on newer runners where buildx adds provenance attestations
- Replaced `docker manifest create` + `docker manifest push` with `docker buildx imagetools create`, which handles manifest list inputs natively

## Test plan
- [ ] Trigger a release and verify the `create-manifest` job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)