### PR TITLE
ci: add conventional commit check for PR titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   workflow_dispatch:
@@ -21,6 +22,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  conventional-commit:
+    name: conventional commit
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   lockfile:
     name: lockfile
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a CI job using `amannn/action-semantic-pull-request` to validate PR titles follow conventional commit format
- Only runs on `pull_request` events
- Ensures PR titles produce valid conventional commits on squash merge, which release-plz relies on for changelog generation

## Test plan
- [x] Verify this PR's own title passes the check
- [ ] Open a PR with a non-conventional title and verify it fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)