### PR TITLE
fix(object_store): merge per-request timeout and retry overrides

### DIFF
--- a/src/object_store/config.rs
+++ b/src/object_store/config.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use aws_sdk_s3::config::{retry::RetryConfig, timeout::TimeoutConfig};
+
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct RequestConfig {
     pub connect_timeout: Option<Duration>,
@@ -23,9 +25,24 @@ impl RequestConfig {
             && self.max_backoff.is_none()
     }
 
+    fn has_timeout_overrides(&self) -> bool {
+        self.connect_timeout.is_some()
+            || self.read_timeout.is_some()
+            || self.operation_timeout.is_some()
+            || self.operation_attempt_timeout.is_some()
+    }
+
+    fn has_retry_overrides(&self) -> bool {
+        self.max_attempts.is_some() || self.initial_backoff.is_some() || self.max_backoff.is_some()
+    }
+
     #[must_use]
-    pub fn timeout_config(&self) -> aws_sdk_s3::config::timeout::TimeoutConfig {
-        let mut builder = aws_sdk_s3::config::timeout::TimeoutConfig::builder();
+    pub fn merged_timeout_config(&self, base: Option<&TimeoutConfig>) -> Option<TimeoutConfig> {
+        if !self.has_timeout_overrides() {
+            return None;
+        }
+
+        let mut builder = base.map_or_else(TimeoutConfig::builder, TimeoutConfig::to_builder);
 
         if let Some(connect_timeout) = self.connect_timeout {
             builder = builder.connect_timeout(connect_timeout);
@@ -40,12 +57,16 @@ impl RequestConfig {
             builder = builder.operation_attempt_timeout(attempt_timeout);
         }
 
-        builder.build()
+        Some(builder.build())
     }
 
     #[must_use]
-    pub fn retry_config(&self) -> aws_sdk_s3::config::retry::RetryConfig {
-        let mut config = aws_sdk_s3::config::retry::RetryConfig::standard();
+    pub fn merged_retry_config(&self, base: Option<&RetryConfig>) -> Option<RetryConfig> {
+        if !self.has_retry_overrides() {
+            return None;
+        }
+
+        let mut config = base.cloned().unwrap_or_else(RetryConfig::standard);
 
         if let Some(max_attempts) = self.max_attempts {
             config = config.with_max_attempts(max_attempts);
@@ -57,6 +78,97 @@ impl RequestConfig {
             config = config.with_max_backoff(max_backoff);
         }
 
-        config
+        Some(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use aws_sdk_s3::config::{retry::RetryConfig, timeout::TimeoutConfig};
+
+    use crate::object_store::config::RequestConfig;
+
+    #[test]
+    fn merged_timeout_config_preserves_unset_base_fields() {
+        let base = TimeoutConfig::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .read_timeout(Duration::from_secs(30))
+            .operation_timeout(Duration::from_secs(60))
+            .operation_attempt_timeout(Duration::from_secs(20))
+            .build();
+        let request = RequestConfig {
+            connect_timeout: Some(Duration::from_secs(5)),
+            ..RequestConfig::default()
+        };
+
+        let merged = request
+            .merged_timeout_config(Some(&base))
+            .expect("timeout overrides are set");
+
+        assert_eq!(merged.connect_timeout(), Some(Duration::from_secs(5)));
+        assert_eq!(merged.read_timeout(), Some(Duration::from_secs(30)));
+        assert_eq!(merged.operation_timeout(), Some(Duration::from_secs(60)));
+        assert_eq!(
+            merged.operation_attempt_timeout(),
+            Some(Duration::from_secs(20))
+        );
+    }
+
+    #[test]
+    fn merged_timeout_config_without_timeout_overrides_is_none() {
+        let request = RequestConfig {
+            max_attempts: Some(5),
+            ..RequestConfig::default()
+        };
+
+        assert!(request.merged_timeout_config(None).is_none());
+    }
+
+    #[test]
+    fn merged_retry_config_preserves_unset_base_fields() {
+        let base = RetryConfig::standard()
+            .with_max_attempts(7)
+            .with_initial_backoff(Duration::from_millis(250))
+            .with_max_backoff(Duration::from_secs(60));
+        let request = RequestConfig {
+            max_attempts: Some(5),
+            ..RequestConfig::default()
+        };
+
+        let merged = request
+            .merged_retry_config(Some(&base))
+            .expect("retry overrides are set");
+
+        assert_eq!(merged.max_attempts(), 5);
+        assert_eq!(merged.initial_backoff(), Duration::from_millis(250));
+        assert_eq!(merged.max_backoff(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn merged_retry_config_without_base_uses_standard_defaults() {
+        let request = RequestConfig {
+            max_attempts: Some(9),
+            ..RequestConfig::default()
+        };
+
+        let merged = request
+            .merged_retry_config(None)
+            .expect("retry overrides are set");
+
+        assert_eq!(merged.max_attempts(), 9);
+        assert_eq!(merged.initial_backoff(), Duration::from_secs(1));
+        assert_eq!(merged.max_backoff(), Duration::from_secs(20));
+    }
+
+    #[test]
+    fn merged_retry_config_without_retry_overrides_is_none() {
+        let request = RequestConfig {
+            connect_timeout: Some(Duration::from_secs(5)),
+            ..RequestConfig::default()
+        };
+
+        assert!(request.merged_retry_config(None).is_none());
     }
 }

--- a/src/object_store/downloader.rs
+++ b/src/object_store/downloader.rs
@@ -182,15 +182,21 @@ impl Downloader {
         if req_config.is_noop() {
             request.send().await
         } else {
+            let client_config = self.s3.config();
+            let mut config_override = client_config.to_builder();
+            if let Some(timeout_config) =
+                req_config.merged_timeout_config(client_config.timeout_config())
+            {
+                config_override = config_override.timeout_config(timeout_config);
+            }
+            if let Some(retry_config) = req_config.merged_retry_config(client_config.retry_config())
+            {
+                config_override = config_override.retry_config(retry_config);
+            }
+
             request
                 .customize()
-                .config_override(
-                    self.s3
-                        .config()
-                        .to_builder()
-                        .timeout_config(req_config.timeout_config())
-                        .retry_config(req_config.retry_config()),
-                )
+                .config_override(config_override)
                 .send()
                 .await
         }


### PR DESCRIPTION
## Summary
- merge per-request timeout overrides with the existing S3 client timeout config instead of replacing it
- merge per-request retry overrides with the existing S3 client retry config instead of resetting to SDK defaults
- apply timeout/retry config overrides independently so unset categories are left untouched
- add unit tests for merge behavior and no-op behavior

## Testing
- cargo +nightly fmt
- cargo clippy --all-features --all-targets -- -D warnings --allow deprecated
- cargo nextest run --lib
- cargo nextest run *(fails in this environment because Docker/MinIO is unavailable: connection refused to container runtime)*

Closes #41