### PR TITLE
build: use Minimus Rust builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build stage
-FROM rust:latest AS builder
+FROM reg.mini.dev/rust:latest AS builder
+
+USER root
 
 WORKDIR /build
 


### PR DESCRIPTION
Replace the public rust:latest builder with reg.mini.dev/rust:latest and run the build stage as root for package installation.

Validated:
- docker build --progress=plain --target runtime -t cachey:minimus-rust-test .
- docker run --rm cachey:minimus-rust-test --help
- cargo +nightly fmt -- --check
- cargo nextest run --all-features (124 passed)
- cargo clippy --all-features --all-targets -- -D warnings --allow deprecated (current-main Rust 1.97 reports 15 useless-borrows-in-formatting warnings in unchanged tests; all other lints pass when that lint is allowed)
- cargo deny check with cargo-deny 0.19.7
- cargo metadata --locked --format-version 1