### PR TITLE
chore: update h2 and fix clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,9 +1898,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/src/object_store/downloader.rs
+++ b/src/object_store/downloader.rs
@@ -1,7 +1,7 @@
 use std::{ops::Range, sync::Arc, time::Duration};
 
 use aws_sdk_s3::{
-    error::ProvideErrorMetadata,
+    error::{ProvideErrorMetadata, SdkError},
     operation::get_object::{GetObjectError, GetObjectOutput},
 };
 use bytes::Bytes;
@@ -14,6 +14,8 @@ use crate::{
     service::SlidingThroughput,
     types::{BucketName, BucketNameSet, ObjectKey},
 };
+
+type GetObjectResult = Result<GetObjectOutput, Box<SdkError<GetObjectError>>>;
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum DownloadError {
@@ -51,7 +53,7 @@ impl DownloadError {
     }
 }
 
-fn invalid_range_object_size(error: &aws_sdk_s3::error::SdkError<GetObjectError>) -> Option<u64> {
+fn invalid_range_object_size(error: &SdkError<GetObjectError>) -> Option<u64> {
     error
         .raw_response()
         .and_then(|response| response.headers().get("content-range"))
@@ -214,10 +216,7 @@ impl Downloader {
         key: &ObjectKey,
         byterange: &Range<u64>,
         req_config: &RequestConfig,
-    ) -> Result<
-        GetObjectOutput,
-        aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
-    > {
+    ) -> GetObjectResult {
         let request = self
             .s3
             .get_object()
@@ -227,7 +226,7 @@ impl Downloader {
             .checksum_mode(aws_sdk_s3::types::ChecksumMode::Enabled);
 
         if req_config.is_noop() {
-            request.send().await
+            request.send().await.map_err(Box::new)
         } else {
             let client_config = self.s3.config();
             let mut config_override = client_config.to_builder();
@@ -249,6 +248,7 @@ impl Downloader {
                 .config_override(config_override)
                 .send()
                 .await
+                .map_err(Box::new)
         }
     }
 
@@ -256,10 +256,7 @@ impl Downloader {
         &self,
         bucket: BucketName,
         req_range: &Range<u64>,
-        result: Result<
-            GetObjectOutput,
-            aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
-        >,
+        result: GetObjectResult,
         latency: Duration,
         hedged: Option<Duration>,
     ) -> Result<ObjectPiece, DownloadError> {
@@ -330,12 +327,12 @@ impl Downloader {
                 }
                 .await
             }
-            Err(e) => {
-                let object_size = invalid_range_object_size(&e);
+            Err(error) => {
+                let object_size = invalid_range_object_size(&error);
                 Err(map_get_object_error(
                     req_range,
                     object_size,
-                    e.into_service_error(),
+                    error.into_service_error(),
                 ))
             }
         };
@@ -544,7 +541,7 @@ mod tests {
             .handle_result(
                 bucket,
                 &req_range,
-                Err(sdk_error),
+                Err(Box::new(sdk_error)),
                 Duration::from_millis(100),
                 None,
             )
@@ -611,7 +608,7 @@ mod tests {
             .handle_result(
                 bucket,
                 &req_range,
-                Err(sdk_error),
+                Err(Box::new(sdk_error)),
                 Duration::from_millis(100),
                 None,
             )

--- a/src/service/routes.rs
+++ b/src/service/routes.rs
@@ -110,6 +110,7 @@ where
 {
     type Rejection = (StatusCode, &'static str);
 
+    #[expect(clippy::unused_async_trait_impl, reason = "synchronous extractor")]
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let range_header = parts
             .headers
@@ -146,6 +147,7 @@ where
 {
     type Rejection = (StatusCode, &'static str);
 
+    #[expect(clippy::unused_async_trait_impl, reason = "synchronous extractor")]
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let Some(header_value) = parts.headers.get(&C0_CONFIG_HEADER) else {
             return Ok(Self::default());
@@ -214,6 +216,7 @@ where
 {
     type Rejection = (StatusCode, &'static str);
 
+    #[expect(clippy::unused_async_trait_impl, reason = "synchronous extractor")]
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let mut names = Vec::with_capacity(3);
         for value in parts.headers.get_all(&C0_BUCKET_HEADER) {


### PR DESCRIPTION
## Summary

- update `h2` from 0.4.15 to 0.4.16 to resolve RUSTSEC-2026-0258
- box S3 get-object SDK errors to satisfy Rust 1.98's large-error lint
- mark the three intentionally synchronous axum extractors as expected by clippy

## Dependency verification

- admitted at the explicitly approved four-day publication age
- verified the checksum against both crates.io metadata and the official registry index
- confirmed dependency, feature, link, and minimum-Rust metadata are unchanged

## Validation

- no Cargo commands, Rust tools, crate downloads, builds, or tests were run locally
- GitHub-hosted CI is the only execution environment for this change
