### PR TITLE
ci: add Rust dependency cooldown gate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[unstable]
+min-publish-age = true
+
+[registry]
+global-min-publish-age = "7 days"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  rust-dependency-cooldown:
+    name: Rust dependency cooldown gate
+    permissions:
+      contents: read
+    uses: s2-streamstore/s2/.github/workflows/rust-dependency-cooldown.yml@97411e90049539d264ea9eda0efd2802548dae6b
+
   conventional-commit:
     name: conventional commit
     if: github.event_name == 'pull_request'
@@ -63,6 +69,7 @@ jobs:
 
   test:
     name: tests
+    needs: rust-dependency-cooldown
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -80,7 +87,7 @@ jobs:
         uses: taiki-e/install-action@d5f9268ff7620505a81ada10ddf18cdd72240185 # nextest
 
       - name: Run tests
-        run: cargo nextest run --all-features
+        run: cargo nextest run --locked --all-features
 
   rustfmt:
     name: rustfmt
@@ -102,6 +109,7 @@ jobs:
 
   clippy:
     name: clippy
+    needs: rust-dependency-cooldown
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,12 +9,16 @@ cachey is a read-through cache for S3-compatible object storage
 - Use `eyre::Report` when the specific error is not as important
 - Use custom error types using `thiserror` for domain-specific errors
 - Format: `cargo +nightly fmt`
-- Lint: `cargo clippy --all-features --all-targets -- -D warnings --allow deprecated`
+- Lint: `cargo clippy --locked --all-features --all-targets -- -D warnings --allow deprecated`
 - Dependency policy: `cargo deny check`
 - Place unit tests in the same file using `#[cfg(test)]` modules
 - Integration tests go in the `tests/` directory
-- Run tests with: `cargo nextest run`
-- Add dependencies to `Cargo.toml`
+- Run tests with: `cargo nextest run --locked`
+- Use `--locked` for Cargo commands that build, check, test, run, document, fetch, or read metadata
+- Use `cargo +nightly add`, `cargo +nightly update`, `cargo +nightly remove`, or `cargo +nightly generate-lockfile` for dependency changes
+- Do not use the stable forms of these dependency commands
+- Do not edit dependency declarations or `Cargo.lock` directly
+- Do not run `cargo install` as part of a coding task
 - Prefer well-maintained crates from crates.io
 - Be mindful of allocations in hot paths
 - Prefer structured logging

--- a/README.md
+++ b/README.md
@@ -132,3 +132,15 @@ Options:
 
 - [justfile](./justfile) contains commands for [just](https://just.systems/man/en/) doing things
 - [AGENTS.md](./AGENTS.md) and symlinks for your favorite coding buddies
+
+Use the nightly Cargo dependency commands so that the seven-day publication cooldown applies:
+
+```bash
+cargo +nightly add <crate>
+cargo +nightly update
+cargo +nightly update -p <crate>
+cargo +nightly remove <crate>
+cargo +nightly generate-lockfile
+```
+
+Use `--locked` with normal build, check, test, run, document, fetch, and metadata commands. The pull request dependency gate verifies each proposed lockfile change before Rust build jobs start.

--- a/justfile
+++ b/justfile
@@ -8,11 +8,11 @@ build:
 
 # Run clippy linter
 clippy:
-    cargo clippy --workspace --all-features --all-targets -- -D warnings --allow deprecated
+    cargo clippy --locked --workspace --all-features --all-targets -- -D warnings --allow deprecated
 
 # Ensure cargo-deny is installed
 _ensure-deny:
-    @cargo deny --version > /dev/null 2>&1 || cargo install cargo-deny
+    @cargo deny --version > /dev/null 2>&1 || (echo "cargo-deny is required; run: brew install cargo-deny" && exit 1)
 
 # Run cargo-deny checks
 deny *args: _ensure-deny
@@ -24,7 +24,7 @@ fmt:
 
 # Run tests with nextest
 test:
-    cargo nextest run --all-features
+    cargo nextest run --locked --all-features
 
 # Run the server locally
 run:


### PR DESCRIPTION
Adds a seven-day publication cooldown for new Rust dependencies and gates compiling CI jobs on the shared dependency check.

Also documents the nightly Cargo dependency workflow and uses locked resolution for normal Cargo commands.