### PR TITLE
fix: allow reads from the final addressable page

### DIFF
--- a/src/service/metrics.rs
+++ b/src/service/metrics.rs
@@ -113,7 +113,7 @@ pub fn fetch_request_bytes(kind: &ObjectKind, bytes: u64) {
         .observe(bytes as f64);
 }
 
-pub fn fetch_request_pages(kind: &ObjectKind, pages: u16) {
+pub fn fetch_request_pages(kind: &ObjectKind, pages: usize) {
     static HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec!(
             "cachey_fetch_request_pages",
@@ -126,7 +126,7 @@ pub fn fetch_request_pages(kind: &ObjectKind, pages: u16) {
 
     HISTOGRAM
         .with_label_values(&[&**kind])
-        .observe(f64::from(pages));
+        .observe(pages as f64);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 
 pub const PAGE_SIZE: u64 = 16 * 1024 * 1024;
 
-pub const MAX_RANGE_END: u64 = PAGE_SIZE * PageId::MAX as u64;
+pub const MAX_RANGE_END: u64 = PAGE_SIZE * (PageId::MAX as u64 + 1);
 
 fn page_id_for_byte_offset(byte_offset: u64) -> PageId {
     (byte_offset / PAGE_SIZE) as PageId
@@ -171,7 +171,7 @@ impl CacheyService {
         let pagerange = pagerange(&byterange);
 
         metrics::fetch_request_bytes(&kind, byterange.end - byterange.start);
-        metrics::fetch_request_pages(&kind, pagerange.end() - pagerange.start() + 1);
+        metrics::fetch_request_pages(&kind, pagerange.len());
 
         let executor = Arc::new(PageGetExecutor {
             downloader: self.downloader,
@@ -349,7 +349,7 @@ mod tests {
     use bytesize::ByteSize;
     use futures::TryStreamExt;
 
-    use super::{CacheyService, PAGE_SIZE, ServiceConfig, ServiceError, pagerange};
+    use super::{CacheyService, PAGE_SIZE, ServiceConfig, ServiceError, metrics, pagerange};
     use crate::{
         cache::{CacheConfig, CacheKey, CacheValue},
         object_store::{DownloadLimits, RequestConfig},
@@ -470,9 +470,44 @@ mod tests {
             (0..2 * PAGE_SIZE, 0..=1),
             (PAGE_SIZE - 1..PAGE_SIZE + 1, 0..=1),
             (PAGE_SIZE..2 * PAGE_SIZE, 1..=1),
+            ((1 << 40) - 1..1 << 40, 65535..=65535),
+            (0..1 << 40, 0..=65535),
         ] {
             assert_eq!(pagerange(&bytes), pages, "{bytes:?}");
         }
+    }
+
+    #[tokio::test]
+    async fn full_address_space_records_all_pages() {
+        let service = CacheyService::new(
+            ServiceConfig {
+                cache: CacheConfig {
+                    memory_size: ByteSize::mib(16),
+                    disk_cache: None,
+                    metrics_registry: None,
+                },
+                download_limits: DownloadLimits::default(),
+            },
+            mock_s3_client("http://unused.invalid"),
+            axum_server::Handle::new(),
+        )
+        .await
+        .unwrap();
+
+        drop(service.get(
+            ObjectKind::new("full-address-space").unwrap(),
+            ObjectKey::new("object").unwrap(),
+            BucketName::new("bucket").unwrap().into(),
+            0..1 << 40,
+            NonZeroUsize::MIN,
+            RequestConfig::default(),
+        ));
+        let snapshot = metrics::gather();
+        assert!(
+            std::str::from_utf8(&snapshot)
+                .unwrap()
+                .contains("cachey_fetch_request_pages_sum{kind=\"full-address-space\"} 65536\n")
+        );
     }
 
     #[tokio::test]

--- a/src/service/routes.rs
+++ b/src/service/routes.rs
@@ -437,13 +437,13 @@ mod tests {
 
     use axum::{
         extract::FromRequestParts,
-        http::{HeaderValue, Method, Request, StatusCode},
+        http::{HeaderValue, Method, Request, StatusCode, header},
     };
 
-    use super::{C0_CONFIG_HEADER, on_chunk_error};
+    use super::{C0_CONFIG_HEADER, RangeHeader, on_chunk_error};
     use crate::{
         object_store::{DownloadError, RequestConfig},
-        service::{ServiceError, metrics},
+        service::{PAGE_SIZE, ServiceError, metrics},
         types::{BucketName, ObjectKind},
     };
 
@@ -456,6 +456,39 @@ mod tests {
         }
         let (mut parts, ()) = request.into_parts();
         RequestConfig::from_request_parts(&mut parts, &()).await
+    }
+
+    #[tokio::test]
+    async fn range_header_allows_the_last_page_within_one_tib() {
+        let limit = 1 << 40;
+        for (range, accepted) in [
+            (limit - PAGE_SIZE..limit, true),
+            (limit - 1..limit, true),
+            (0..limit, true),
+            (0..limit + 1, false),
+            (limit..limit + 1, false),
+        ] {
+            let request = Request::builder()
+                .header(
+                    header::RANGE,
+                    format!("bytes={}-{}", range.start, range.end - 1),
+                )
+                .body(())
+                .unwrap();
+            let (mut parts, ()) = request.into_parts();
+            let result = RangeHeader::from_request_parts(&mut parts, &())
+                .await
+                .map(|header| header.0)
+                .map_err(|(status, _)| status);
+            assert_eq!(
+                result,
+                if accepted {
+                    Ok(range)
+                } else {
+                    Err(StatusCode::RANGE_NOT_SATISFIABLE)
+                }
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
HTTP range validation rejected page 65535, excluding the final 16 MiB of the 1 TiB address space. Include that page in the exclusive upper bound and use the range iterator's `usize` length so requests spanning all 65,536 pages cannot overflow page-count accounting.

Regression coverage checks HTTP acceptance and rejection at the limit, final-page mapping, and full-range metrics without downloading object data. The new tests reproduced both the original rejection and the overflow exposed by fixing only the bound.

Validation: 100 tests passed, 1 ignored with `cargo nextest run --locked --all-features`; nightly formatting, Clippy across all features and targets with warnings denied, `cargo deny check`, and `git diff --check` passed.

Closes #127
